### PR TITLE
require dataclasses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tqdm
 click
 regex
 typer>=0.3.2
+dataclasses


### PR DESCRIPTION
namedivider-python requires dataclasses

https://github.com/rskmoi/namedivider-python/commit/5b0e4feebb6900597f28ad844e7010f25e3dbf23#diff-100314e4e369ff5e7bc6880100eab5ca45f3b6d5616e28125e33d688726a5bd7R2