### PR TITLE
Fix unintended behavior in kanji_kana_rule.py

### DIFF
--- a/namedivider/rule/kanji_kana_rule.py
+++ b/namedivider/rule/kanji_kana_rule.py
@@ -49,4 +49,15 @@ class KanjiKanaRule(Rule):
                         algorithm="rule",
                     )
 
+        # If there is only one kanji within the name, and the last character of the name is a kanji,
+        # then that last character is considered the given name. (ex: ながつま昭)
+        if sum(is_kanji_list) == 1 and is_kanji_list[-1] is True:
+            return DividedName(
+                family=undivided_name[:-1],
+                given=undivided_name[-1:],
+                separator=separator,
+                score=1.0,
+                algorithm="rule",
+            )
+
         return None

--- a/tests/rule/test_kanji_kana_rule.py
+++ b/tests/rule/test_kanji_kana_rule.py
@@ -7,6 +7,7 @@ from namedivider.rule.kanji_kana_rule import KanjiKanaRule
 name_test_data = [
     ("中山マサ", {"family": "中山", "given": "マサ", "separator": "/", "score": 1.0, "algorithm": "rule"}),
     ("つるの剛士", {"family": "つるの", "given": "剛士", "separator": "/", "score": 1.0, "algorithm": "rule"}),
+    ("ながつま昭", {"family": "ながつま", "given": "昭", "separator": "/", "score": 1.0, "algorithm": "rule"}),
 ]
 
 


### PR DESCRIPTION
If there is only one kanji within the name, and the last character of the name is a kanji, the name will be divided by rule-based algorithm. (like ながつま昭)

Previously, it was unforeseen that rule-based algorithms would not be applied in this case. Therefore, the output may vary compared to the previous version in this case.