### PR TITLE
Support Python 3.13, end support Python 3.8, upgrade CI libraries

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,9 +29,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install libomp if the operating system is macOS.
         if: matrix.os == 'macos-latest'
         run: brew install libomp

--- a/namedivider/beta_bert_divider/bert_name_divider_only_katakana.py
+++ b/namedivider/beta_bert_divider/bert_name_divider_only_katakana.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-defs
 import json
 from pathlib import Path
 from typing import Tuple, Union

--- a/namedivider/beta_bert_divider/bert_name_divider_only_katakana.py
+++ b/namedivider/beta_bert_divider/bert_name_divider_only_katakana.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import Tuple, Union
 
-import torch  # type: ignore
+import torch
 from transformers import BertForSequenceClassification, PretrainedConfig  # type: ignore
 
 from namedivider.divider.divided_name import DividedName

--- a/namedivider/beta_bert_divider/bert_name_divider_only_katakana.py
+++ b/namedivider/beta_bert_divider/bert_name_divider_only_katakana.py
@@ -1,9 +1,8 @@
-# mypy: allow-untyped-defs
 import json
 from pathlib import Path
 from typing import Tuple, Union
 
-import torch
+import torch  # type: ignore
 from transformers import BertForSequenceClassification, PretrainedConfig  # type: ignore
 
 from namedivider.divider.divided_name import DividedName

--- a/namedivider/divider/gbdt_name_divider.py
+++ b/namedivider/divider/gbdt_name_divider.py
@@ -1,8 +1,8 @@
+import _pickle as pickle  # type: ignore
 from dataclasses import asdict
 from pathlib import Path
 from typing import Optional, cast
 
-import _pickle as pickle  # type: ignore
 import lightgbm as lgb
 import pandas as pd
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ module = "namedivider"
 ignore_missing_imports = true
 
 [tool.ruff]
-select = [
+lint.select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
     "F",  # pyflakes
@@ -70,7 +70,7 @@ select = [
     "C",  # flake8-comprehensions
     "B",  # flake8-bugbear
 ]
-ignore = [
+lint.ignore = [
     "E501",  # line too long, handled by black
     "B008",  # do not perform function calls in argument defaults
     "C901",  # too complex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,11 @@ authors = [
 ]
 classifiers = [
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "lightgbm>=3.3",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 pytest >=7.1.3,<8.0.0
 mypy == 1.11.2
 ruff == 0.6.8
-black == 24.8.0
+black == 23.12.1
 coverage == 7.6.1
 
 # stubs

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,8 @@
 pytest >=7.1.3,<8.0.0
-mypy == 1.4.0
-ruff == 0.0.275
-black == 23.3.0
-coverage == 7.3.2
+mypy == 1.11.2
+ruff == 0.6.8
+black == 24.8.0
+coverage == 7.6.1
 
 # stubs
 types-requests

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,2 +1,2 @@
-ruff namedivider tests --fix
+ruff check namedivider tests --fix
 black namedivider tests

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,5 +2,5 @@ set -e
 set -x
 
 mypy namedivider
-ruff namedivider tests
+ruff check namedivider tests
 black namedivider tests --check


### PR DESCRIPTION
- Support Python 3.13 (add tests)
- End support python 3.8
- Upgrade CI libraries
  - mypy, ruff, black, coverage