### PR TITLE
Replaced requests with urllib from the standard library

### DIFF
--- a/namedivider/util.py
+++ b/namedivider/util.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Union
 
-import requests
+import urllib.request
 
 CURRENT_DIR = Path(__file__).resolve().parent
 DEFAULT_CACHE_DIR = Path("~/.cache/namedivider-python").expanduser()
@@ -43,7 +43,8 @@ def download_family_name_pickle_if_needed(path: Union[str, Path]) -> None:
         return None
     DEFAULT_CACHE_DIR.mkdir(exist_ok=True, parents=True)
     print("Download FamilyNameRepository from GitHub...")
-    content = requests.get(FAMILY_NAME_REPOSITORY_URL).content
+    with urllib.request.urlopen(FAMILY_NAME_REPOSITORY_URL) as response:
+        content = response.read()
     with open(path, "wb") as f:
         f.write(content)
 
@@ -59,6 +60,7 @@ def download_gbdt_model_v1_if_needed(path: Union[str, Path]) -> None:
         return None
     DEFAULT_CACHE_DIR.mkdir(exist_ok=True, parents=True)
     print("Download GBDT Model from GitHub...")
-    content = requests.get(GBDT_MODEL_V1_URL).content
+    with urllib.request.urlopen(GBDT_MODEL_V1_URL) as response:
+        content = response.read()
     with open(path, "wb") as f:
         f.write(content)

--- a/namedivider/util.py
+++ b/namedivider/util.py
@@ -1,7 +1,6 @@
+import urllib.request
 from pathlib import Path
 from typing import Union
-
-import urllib.request
 
 CURRENT_DIR = Path(__file__).resolve().parent
 DEFAULT_CACHE_DIR = Path("~/.cache/namedivider-python").expanduser()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "numpy",
     "pandas",
     "regex",
-    "requests",
     "tqdm",
     "typer>=0.3.2",
 ]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,6 @@ black == 23.3.0
 coverage == 7.3.2
 
 # stubs
-types-requests
 pandas-stubs
 types-regex
 types-tqdm


### PR DESCRIPTION
In this Pull Request, I have removed the usage of the requests library to reduce dependencies and changed it to use the standard library urllib instead. 
This aims to lighten the project and improve maintainability.

I have reviewed all instances where the requests library was used and replaced them with urllib.