### PR TITLE
Speed improvement: preprocessing without using pandas

### DIFF
--- a/namedivider/divider/gbdt_name_divider.py
+++ b/namedivider/divider/gbdt_name_divider.py
@@ -46,7 +46,7 @@ class GBDTNameDivider(_NameDivider):
         :return: Score of dividing.
         """
         feature = self.feature_extractor.get_features(family=family, given=given)
-        feature_list = ([list(asdict(feature).values())])
+        feature_list = [list(asdict(feature).values())]
         score_list = self.model.predict(feature_list)
         score = cast(float, score_list[0])
         return score

--- a/namedivider/divider/gbdt_name_divider.py
+++ b/namedivider/divider/gbdt_name_divider.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Optional, cast
 
 import lightgbm as lgb
-import pandas as pd
 
 from namedivider.divider.config import GBDTNameDividerConfig
 from namedivider.divider.name_divider_base import _NameDivider
@@ -47,7 +46,7 @@ class GBDTNameDivider(_NameDivider):
         :return: Score of dividing.
         """
         feature = self.feature_extractor.get_features(family=family, given=given)
-        df = pd.DataFrame([asdict(feature)])
-        score_list = self.model.predict(df)
+        feature_list = ([list(asdict(feature).values())])
+        score_list = self.model.predict(feature_list)
         score = cast(float, score_list[0])
         return score


### PR DESCRIPTION
Achieved a performance improvement by inputting features directly into LightGBM, bypassing pandas DataFrame. This is particularly effective when processing large datasets on a GPU.

- Example 1: Inference on 10,000 names with GPU

Before: 107.008s  
After: 38.383s

- Example 2: Inference on 10,000 names without GPU

Before: 162.693s  
After: 146.861s